### PR TITLE
Prevent mint when prediction modal is dismissed

### DIFF
--- a/main.js
+++ b/main.js
@@ -855,7 +855,7 @@ async function showPredictionModal() {
     modal.onclick = (e) => {
       if (e.target === modal) {
         cleanup();
-        resolve({ skip: true });
+        resolve({ skip: true, cancelled: true });
       }
     };
   });
@@ -2269,6 +2269,11 @@ mintBtn.addEventListener('click', async () => {
     const predictionResult = await showPredictionModal();
     
     console.log('Prediction result:', predictionResult);
+
+    if (predictionResult.cancelled) {
+      setStatus('Mint cancelled.', 'info');
+      return;
+    }
     
     statusBox.innerHTML = '';
     statusBox.className = 'status-box';


### PR DESCRIPTION
### Motivation
- Clicking outside the prediction modal previously resolved the modal as a skip and allowed the mint flow to continue, which caused unintended transactions when the user dismissed the modal; the intent is to treat outside-click dismissals as an explicit cancellation and stop the mint.

### Description
- Mark outside-click dismissals in `showPredictionModal()` by resolving the modal promise with `{ skip: true, cancelled: true }` instead of only `{ skip: true }` (updated `main.js`).
- Abort the mint flow early in the `mintBtn` click handler by checking `predictionResult.cancelled`, setting a user status message, and returning before any transaction is submitted (updated `main.js`).
- Changes are confined to `main.js` and preserve the existing skip behavior for explicit "Skip" button clicks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698607d53fb8833293313fcb53311166)