### PR TITLE
Fix connect button doing nothing after disconnect

### DIFF
--- a/main.js
+++ b/main.js
@@ -2292,8 +2292,8 @@ connectBtn.addEventListener('click', async () => {
         userAddress = conn.accounts[0];
         showAddress(userAddress);
         setStatus('MiniPay connected! Gas is paid in cUSD.', 'success');
+        return;
       }
-      return;
     }
     // Farcaster: connect directly via farcasterMiniApp connector — no modal needed
     if (isFarcasterEnvironment) {
@@ -2303,15 +2303,19 @@ connectBtn.addEventListener('click', async () => {
         userAddress = conn.accounts[0];
         showAddress(userAddress);
         setStatus('Connected via Farcaster!', 'success');
+        return;
       }
-      return;
     }
+    // Fallback: open AppKit modal (browser, or if direct connector not found)
     if (modal) {
       modal.open();
     }
   } catch (error) {
     console.error('Connect button error:', error);
-    setStatus('Failed to connect wallet.', 'error');
+    // On error in Farcaster/MiniPay, fall back to modal as last resort
+    if (modal) {
+      modal.open();
+    }
   }
 });
 


### PR DESCRIPTION
## Problem

After disconnecting, tapping "Connect Wallet" did nothing.

**Root cause:** The `return` statements in the MiniPay and Farcaster branches were placed *outside* the `if (connector)` guard. So when `wagmiConfig.connectors.find(...)` returned `undefined` (which can happen after a disconnect/reconnect cycle resets connector state), the function hit `return` and exited silently — never reaching `modal.open()`.

## Fix

Moved `return` inside the success block so it only exits early on a successful direct connect. Any failure (connector not found, or thrown error) now falls through to `modal.open()` as a reliable fallback.